### PR TITLE
Disguising BoringSSL as OpenSSL for `find_package(OpenSSL)`to work

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,0 +1,6 @@
+{ 
+    "u" : true
+    , "packages" : ["OpenSSL"]
+    , "targets" : ["OpenSSL::SSL", "OpenSSL::Crypto"]
+    , "find_mode" : "MODULE"
+}

--- a/.tipi/id
+++ b/.tipi/id
@@ -1,0 +1,1 @@
+{"host_name":"github.com","org_name":"nxxm","repo_name":"boringssl"}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,7 @@ elseif(MSVC)
       "C5027" # move assignment operator was implicitly defined as deleted
       "C5045" # Compiler will insert Spectre mitigation for memory load if
               # /Qspectre switch specified
+      "C5039" # accepts noexcept code that may throw from C boundaries
       )
   set(MSVC_LEVEL4_WARNINGS_LIST
       # See https://connect.microsoft.com/VisualStudio/feedback/details/1217660/warning-c4265-when-using-functional-header
@@ -260,8 +261,8 @@ elseif(MSVC)
                             ${MSVC_DISABLED_WARNINGS_LIST})
   string(REPLACE "C" " -w4" MSVC_LEVEL4_WARNINGS_STR
                             ${MSVC_LEVEL4_WARNINGS_LIST})
-  set(CMAKE_C_FLAGS   "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
-  set(CMAKE_CXX_FLAGS "-utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
+  set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -utf-8 -Wall -WX ${MSVC_DISABLED_WARNINGS_STR} ${MSVC_LEVEL4_WARNINGS_STR}")
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ endif()
 # Defer enabling C and CXX languages.
 project(BoringSSL VERSION 0.0.0 LANGUAGES NONE)
 
+# BoringSSL disguise itself in OpenSSL and to be found by FindOpenSSL.camke it needs to have no d a the end of "crypto**d**.lib / .so" name.
+set (CMAKE_DEBUG_POSTFIX "" CACHE STRING "Disable the unhelpful d at end of library filenames" FORCE)
+
 ###############
 ### Install ###
 ###############

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -16,3 +16,12 @@
    OpenSSL easier. */
 
 #include "crypto.h"
+
+/* Backward compatibility code for the stock FindOpenSSL.cmake from CMake */
+#ifndef OPENSSL_IS_BORINGSSL
+   #define OPENSSL_IS_BORINGSSL
+#endif
+
+#ifndef OPENSSL_VERSION_NUMBER
+   #define OPENSSL_VERSION_NUMBER 0x1010107f
+#endif

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -19,9 +19,9 @@
 
 /* Backward compatibility code for the stock FindOpenSSL.cmake from CMake */
 #ifndef OPENSSL_IS_BORINGSSL
-   #define OPENSSL_IS_BORINGSSL
+#define OPENSSL_IS_BORINGSSL
 #endif
 
 #ifndef OPENSSL_VERSION_NUMBER
-   #define OPENSSL_VERSION_NUMBER 0x1010107f
+#define OPENSSL_VERSION_NUMBER 0x1010107f
 #endif


### PR DESCRIPTION
This allows using BoringSSL as OpenSSL.

CMake `find_package(OpenSSL)` from FindModules shipped in CMake 3.21 work seamlessly with it on : 
- clang linux
- clang macos
- clang on windows
- MSVC with MSBuild : vs-16-2019-win64-cxx17


Fix nxxm/nxxm-src#1010
